### PR TITLE
Serialize and Deserialize instances for sexp itself

### DIFF
--- a/theories/Deserialize.v
+++ b/theories/Deserialize.v
@@ -321,3 +321,5 @@ Instance Deserialize_list {A} `{Deserialize A} : Deserialize (list A) :=
     | Atom _ => inl (DeserError l "could not read 'list', got atom"%string)
     | List es => _sexp_to_list _from_sexp nil 0 l es
     end.
+
+Instance Deserialize_sexp : Deserialize (sexp atom) := fun _ => inr.

--- a/theories/Serialize.v
+++ b/theories/Serialize.v
@@ -61,3 +61,5 @@ Instance Serialize_string : Serialize string := Str.
 
 Instance Serialize_list {A} `{Serialize A} : Serialize (list A)
   := fun xs => List (List.map to_sexp xs).
+
+Instance Serialize_sexp : Serialize (sexp atom) := id.


### PR DESCRIPTION
Do we really need the generalized `Serialize_sexp_` and `Deserialize_sexp_`?