### PR TITLE
Prefix all modules with Ceres

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ Require Import Ceres.Ceres.
 
 This exports:
 
-- `Ceres.S`: the core definitions for S-expressions.
-- `Ceres.Serialize`: the `Serialize` type class.
-- `Ceres.Deserialize`: the `Deserialize` type class.
+- `CeresS`: the core definitions for S-expressions.
+- `CeresSerialize`: the `Serialize` type class.
+- `CeresDeserialize`: the `Deserialize` type class.
 
 Other modules in the library:
 
-- `Ceres.S_Format`: format S-expressions as strings.
-- `Ceres.Parser`: S-expression parser.
-- `Ceres.String`: general string utilities.
+- `CeresFormat`: format S-expressions as strings.
+- `CeresParser`: S-expression parser.
+- `CeresString`: general string utilities.
 
 Core definitions
 ----------------

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,8 +1,8 @@
 -Q theories/ Ceres
-theories/String.v
-theories/S.v
-theories/Format.v
-theories/Serialize.v
+theories/CeresString.v
+theories/CeresS.v
+theories/CeresFormat.v
+theories/CeresSerialize.v
+theories/CeresParser.v
+theories/CeresDeserialize.v
 theories/Ceres.v
-theories/Parser.v
-theories/Deserialize.v

--- a/test/Test.v
+++ b/test/Test.v
@@ -1,5 +1,5 @@
 From Coq Require Import List NArith ZArith String.
-From Ceres Require Import Ceres Parser.
+From Ceres Require Import Ceres CeresParser.
 
 Import ListNotations.
 

--- a/theories/Ceres.v
+++ b/theories/Ceres.v
@@ -2,6 +2,6 @@
 
 (** Exported by default. *)
 From Ceres Require Export
-  S
-  Serialize
-  Deserialize.
+  CeresS
+  CeresSerialize
+  CeresDeserialize.

--- a/theories/CeresDeserialize.v
+++ b/theories/CeresDeserialize.v
@@ -7,9 +7,9 @@ From Coq Require Import
   String.
 
 From Ceres Require Import
-  S
-  Parser
-  String.
+  CeresS
+  CeresParser
+  CeresString.
 
 Generalizable Variables A.
 
@@ -58,7 +58,7 @@ Definition type_error (tyname : string) (msg : message) : message :=
 
 (** Errors which may occur when deserializing S-expressions. *)
 Variant error :=
-| ParseError : Parser.error -> error     (* Errors from parsing [string -> sexp atom] *)
+| ParseError : CeresParser.error -> error     (* Errors from parsing [string -> sexp atom] *)
 | DeserError : loc -> message -> error   (* Errors from deserializing [sexp atom -> A] *)
 .
 
@@ -150,7 +150,7 @@ Definition match_con {A} (tyname : string)
   _con tyname
     (fun c l =>
       let all_con := List.map fst c0 in
-      _find_or String.eqb c c0 inr
+      _find_or CeresString.eqb c c0 inr
         (let msg :=
            match all_con with
            | nil => MsgStr "unexpected atom (expected list)"%string
@@ -161,7 +161,7 @@ Definition match_con {A} (tyname : string)
          in inl (DeserError l (type_error tyname msg))))
     (fun c =>
       let all_con := List.map fst c1 in
-      _find_or String.eqb c c1 (fun x => x)
+      _find_or CeresString.eqb c c1 (fun x => x)
         (fun l _ _ =>
           let msg :=
             match all_con with

--- a/theories/CeresFormat.v
+++ b/theories/CeresFormat.v
@@ -1,13 +1,11 @@
 
 (* begin hide *)
-Require Import Coq.Lists.List.
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.Strings.Ascii.
-Require Import Coq.Strings.String.
+From Coq Require Import
+  List ZArith Ascii String.
 
 From Ceres Require Import
-  String
-  S.
+  CeresString
+  CeresS.
 (* end hide *)
 
 (** Helper for [string_of_sexp]. *)

--- a/theories/CeresParser.v
+++ b/theories/CeresParser.v
@@ -3,7 +3,7 @@
 (* begin hide *)
 From Coq Require Import ZArith NArith Ascii String Decimal DecimalString.
 
-From Ceres Require Import S String.
+From Ceres Require Import CeresS CeresString.
 (* end hide *)
 
 (** Location in a string *)

--- a/theories/CeresS.v
+++ b/theories/CeresS.v
@@ -1,10 +1,8 @@
 (** * S-expressions *)
 
 (* begin hide *)
-Require Import Coq.Lists.List.
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.Strings.Ascii.
-Require Import Coq.Strings.String.
+From Coq Require Import
+  List ZArith Ascii String.
 (* end hide *)
 
 (** S-expressions, parameterized by the type of atoms. *)

--- a/theories/CeresSerialize.v
+++ b/theories/CeresSerialize.v
@@ -7,9 +7,9 @@ From Coq Require Import
   String.
 
 From Ceres Require Import
-  S
-  Format
-  String.
+  CeresS
+  CeresFormat
+  CeresString.
 (* end hide *)
 
 (** Serialization to S-expressions. *)

--- a/theories/CeresString.v
+++ b/theories/CeresString.v
@@ -22,8 +22,6 @@ Fixpoint eqb s1 s2 : bool :=
   | _,_ => false
   end.
 
-Infix "=?" := eqb : string_scope.
-
 Fixpoint _string_reverse (r s : string) : string :=
   match s with
   | "" => r


### PR DESCRIPTION
`Format` and `String` are OCaml standard library modules,
and the other modules have generic enough names that
they are bound to cause issues too.

Ideally the Extraction plugin should use the full logical
path to produce the module name, so `theories/String.v`
extracts to `Ceres__String` for instance.
But for backwards compatibility, we're stuck with this kind
of manual mangling.

Ping @liyishuai @YaZKo so you know it's coming.