### PR TITLE
Prove some roundtrip properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,54 +1,52 @@
-defaults: &defaults
-  environment:
-    OPAMVERBOSE: 1
-    OPAMWITHTEST: true
-    OPAMYES: true
-    TERM: xterm
-  steps:
-  - checkout
-  - run:
-      name: Configure environment
-      command: echo . ~/.profile >> $BASH_ENV
-  - run: 
-      name: List installed packages
-      command: opam list
-  - run:
-      name: Compile Cérès
-      command: opam install ./coq-ceres.opam
-
+version: 2.1
 jobs:
-  coq.8.8:
-    <<: *defaults
+  test:
+    parameters:
+      runtest:
+        type: boolean
+        default: true
+      coq:
+        type: string
     docker:
-    - image: coqorg/coq:8.8
-  coq.8.9:
-    <<: *defaults
-    docker:
-    - image: coqorg/coq:8.9
-  coq.8.10:
-    <<: *defaults
-    docker:
-    - image: coqorg/coq:8.10
-  coq.8.11:
-    <<: *defaults
-    docker:
-    - image: coqorg/coq:8.11
-  coq.8.12:
-    <<: *defaults
-    docker:
-    - image: coqorg/coq:8.12
-  coq.dev:
-    <<: *defaults
-    docker:
-    - image: coqorg/coq:dev
+      - image: coqorg/coq:<<parameters.coq>>
+    environment:
+      OPAMVERBOSE: 1
+      OPAMWITHTEST: << parameters.runtest >>
+      OPAMYES: true
+      TERM: xterm
+    steps:
+      - checkout
+      - run:
+          name: Configure environment
+          command: echo . ~/.profile >> $BASH_ENV
+      - run:
+          name: List installed packages
+          command: opam list
+      - run:
+          name: Compile Cérès
+          command: opam install ./coq-ceres.opam
 
 workflows:
   version: 2
   build:
     jobs:
-    - coq.8.8
-    - coq.8.9
-    - coq.8.10
-    - coq.8.11
-    - coq.8.12
-    - coq.dev
+      - test:
+          coq: '8.8'
+          name: 'Coq 8.8'
+          runtest: false
+      - test:
+          coq: '8.9'
+          name: 'Coq 8.9'
+          runtest: false
+      - test:
+          coq: '8.10'
+          name: 'Coq 8.10'
+      - test:
+          coq: '8.11'
+          name: 'Coq 8.11'
+      - test:
+          coq: '8.12'
+          name: 'Coq 8.12'
+      - test:
+          coq: 'dev'
+          name: 'Coq dev'

--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ Class SemiIntegral (A : Type) : Type :=
 Instance Deserialize_SemiIntegral (A : Type) : SemiIntegral A -> Deserialize A.
 ```
 
+Generic types
+-------------
+
+### Recursive types
+
+Recursive serializers and deserializers can be defined using explicit fixpoints.
+
+For deserializers, that means to bind the expression explicitly, since that's
+the decreasing argument, but immediately pass it as the last argument of
+`Deser.match_con`:
+
+```coq
+Definition Deserialize_unary : Deserialize nat :=
+  fix deser_nat (l : loc) (e : sexp) {struct e} :=
+    Deser.match_con "nat"
+      [ ("Z", 0%nat) ]%string
+      [ ("S", Deser.con1 S deser_nat) ]%string l e.
+```
+
 See also
 --------
 

--- a/_CoqProject.classic
+++ b/_CoqProject.classic
@@ -5,4 +5,5 @@ theories/CeresFormat.v
 theories/CeresSerialize.v
 theories/CeresParser.v
 theories/CeresDeserialize.v
+theories/CeresRoundtrip.v
 theories/Ceres.v

--- a/test/Test.v
+++ b/test/Test.v
@@ -78,3 +78,12 @@ Lemma parse_10 :
   e3 = None /\
   e4 = Some (Atom 34%Z).
 Proof. split; split; split; reflexivity. Qed.
+
+(**)
+
+(* Test that recursive deserializers are supported. *)
+Definition Deserialize_unary : Deserialize nat :=
+  fix deser_nat l (e : sexp) {struct e} :=
+    Deser.match_con (A := nat) "nat"
+      [ ("Z", 0%nat) ]%list
+      [ ("S", Deser.con1 S deser_nat) ]%list l e.

--- a/theories/CeresDeserialize.v
+++ b/theories/CeresDeserialize.v
@@ -4,6 +4,7 @@
 From Coq Require Import
   List
   ZArith
+  Ascii
   String.
 
 From Ceres Require Import
@@ -329,6 +330,17 @@ Instance Deserialize_string : Deserialize string :=
     | Atom_ _ => inl (DeserError l "could not read 'string', got non-string atom"%string)
     | List _ => inl (DeserError l "could not read 'string', got list"%string)
     end.
+
+Instance Deserialize_ascii : Deserialize ascii :=
+  fun l e =>
+    match e with
+    | Atom_ (Str (c :: "")) => inr c
+    | Atom_ (Str "") => inl (DeserError l "could not read 'ascii', got empty string")
+    | Atom_ (Str (_ :: _ :: _)) =>
+      inl (DeserError l "could not read 'ascii', got string of length greater than 1")
+    | Atom_ _ => inl (DeserError l "could not read 'ascii', got non-string atom")
+    | List _ => inl (DeserError l "could not read 'ascii', got lost")
+    end%string.
 
 Fixpoint _sexp_to_list {A} (pa : FromSexp A) (xs : list A)
   (n : nat) (l : loc) (ys : list sexp) : error + list A :=

--- a/theories/CeresDeserialize.v
+++ b/theories/CeresDeserialize.v
@@ -230,16 +230,20 @@ Definition con5 {A B C D E R} (f : A -> B -> C -> D -> E -> R)
     fields (pa >>= fun a => pb >>= fun b => pc >>= fun c => pd >>= fun d => pe >>= fun e =>
     ret (f a b c d e)).
 
-Definition con1_ {A R} (f : A -> R) : forall `{Deserialize A}, FromSexpList R := con1 f.
-Definition con2_ {A B R} (f : A -> B -> R)
-  : forall `{Deserialize A} `{Deserialize B}, FromSexpList R := con2 f.
+Definition con1_ {A R} (f : A -> R) `{Deserialize A} : FromSexpList R :=
+  con1 f _from_sexp.
+Definition con2_ {A B R} (f : A -> B -> R) `{Deserialize A} `{Deserialize B} : FromSexpList R :=
+  con2 f _from_sexp _from_sexp.
 Definition con3_ {A B C R} (f : A -> B -> C -> R)
-  : forall `{Deserialize A} `{Deserialize B} `{Deserialize C}, FromSexpList R := con3 f.
+    `{Deserialize A} `{Deserialize B} `{Deserialize C} : FromSexpList R :=
+  con3 f _from_sexp _from_sexp _from_sexp.
 Definition con4_ {A B C D R} (f : A -> B -> C -> D -> R)
-  : forall `{Deserialize A} `{Deserialize B} `{Deserialize C} `{Deserialize D}, FromSexpList R := con4 f.
+    `{Deserialize A} `{Deserialize B} `{Deserialize C} `{Deserialize D} : FromSexpList R :=
+  con4 f _from_sexp _from_sexp _from_sexp _from_sexp.
 Definition con5_ {A B C D E R} (f : A -> B -> C -> D -> E -> R)
-  : forall `{Deserialize A} `{Deserialize B} `{Deserialize C} `{Deserialize D} `{Deserialize E}, FromSexpList R :=
-  con5 f.
+    `{Deserialize A} `{Deserialize B} `{Deserialize C} `{Deserialize D} `{Deserialize E}
+  : FromSexpList R :=
+  con5 f  _from_sexp _from_sexp _from_sexp _from_sexp _from_sexp.
 
 Class DeserFromSexpList (A R : Type) (n m : nat) :=
   _from_sexp_list : A -> FromSexpListN n m R.

--- a/theories/CeresDeserialize.v
+++ b/theories/CeresDeserialize.v
@@ -361,12 +361,3 @@ Instance Deserialize_list {A} `{Deserialize A} : Deserialize (list A) :=
     end.
 
 Instance Deserialize_sexp : Deserialize sexp := fun _ => inr.
-
-(**)
-
-(* Test that recursive deserializers are supported. *)
-Definition Deserialize_unary : Deserialize nat :=
-  fix deser_nat (l : loc) (e : sexp) {struct e} :=
-    Deser.match_con "nat"
-      [ ("Z", 0%nat) ]%string
-      [ ("S", Deser.con1 S deser_nat) ]%string l e.

--- a/theories/CeresRoundtrip.v
+++ b/theories/CeresRoundtrip.v
@@ -125,6 +125,13 @@ Proof.
       * right; constructor; [ constructor; auto | auto ].
 Qed.
 
+(* For backwards compatibility. [List.Exists_impl] which was added on 8.10. *)
+Lemma List_Exists_impl {A} (P Q : A -> Prop) (xs : list A)
+  : (forall x, P x -> Q x) -> List.Exists P xs -> List.Exists Q xs.
+Proof.
+  induction 2; intros; auto.
+Qed.
+
 Theorem de_match_con {A} (tyname : string)
     (c0 : list (string * A)) (c1 : list (string * FromSexpList A))
     l (e : sexp) (a : A)
@@ -137,13 +144,13 @@ Proof.
   unfold Deser.match_con.
   intros DESER. apply de__con in DESER. destruct DESER as [ (c & Ee & Ea ) | (c & es & Ee & Ea) ].
   - apply _find_or_spec in Ea. destruct Ea as [ Ea | [] ]; [ | discriminate ].
-    left. revert Ea; apply List.Exists_impl.
+    left. revert Ea; apply List_Exists_impl.
     intros [] [Es Ea]; cbn in *.
     apply CeresString.eqb_eq_string in Es.
     injection Ea; intros.
     subst. auto.
   - apply _find_or_spec in Ea. destruct Ea as [ Ea | [] ]; [ | discriminate ].
-    right. revert Ea; apply List.Exists_impl.
+    right. revert Ea; apply List_Exists_impl.
     intros [] [Es Ea]; cbn in *.
     apply CeresString.eqb_eq_string in Es.
     exists es.

--- a/theories/CeresRoundtrip.v
+++ b/theories/CeresRoundtrip.v
@@ -1,0 +1,173 @@
+From Coq Require Import
+  List
+  String.
+From Ceres Require Import
+  CeresS
+  CeresSerialize
+  CeresDeserialize.
+
+Import ListNotations.
+
+Definition SerDe {A : Type} (ser : A -> sexp) (de : sexp -> error + A) : Prop :=
+  forall (a : A), de (ser a) = inr a.
+
+Definition map_sum {A B B' : Type} (f : B -> B') (x : A + B) : A + B' :=
+  match x with
+  | inl a => inl a
+  | inr b => inr (f b)
+  end.
+
+Definition DeSer {A : Type} (ser : A -> sexp) (de : sexp -> error + A) : Prop :=
+  forall (e : sexp) (a : A),
+    de e = inr a ->
+    ser a = e.
+
+Class SerDeClass (A : Type) `{Serialize A} `{Deserialize A} : Prop :=
+  ser_de_class : forall l, @SerDe A to_sexp (_from_sexp l).
+
+Class DeSerClass (A : Type) `{Serialize A} `{Deserialize A} : Prop :=
+  de_ser_class : forall l, @DeSer A to_sexp (_from_sexp l).
+
+Lemma de__con {A} (tyname : string)
+    (g : string -> loc -> error + A) (f : string -> FromSexpList A)
+    l (e : sexp) (a : A)
+  : Deser._con tyname g f l e = inr a ->
+    (exists c, e = Atom (Raw c) /\ g c l = inr a) \/
+    (exists c es, e = List (Atom (Raw c) :: es) /\ f c l (type_error tyname) es = inr a).
+Proof.
+  destruct e as [ [] | [ | [ [] | ] ] ]; cbn; try discriminate; eauto.
+Qed.
+
+Lemma _find_or_spec {A B C}
+    (eqb : A -> A -> bool) (a : A) (xs : list (A * B)) (f : B -> C) (b : C)
+    (P : C -> Prop)
+  : P (_find_or eqb a xs f b) ->
+    (List.Exists (fun p => eqb a (fst p) = true /\ P (f (snd p))) xs) \/
+    (List.Forall (fun p => eqb a (fst p) = false) xs /\ P b).
+Proof.
+  induction xs as [ | xy xs IH ].
+  - auto.
+  - cbn. destruct xy as [x y].
+    destruct (eqb a x) eqn:Eeqb.
+    + left; left; auto.
+    + intros H; specialize (IH H).
+      destruct IH as [ | [] ].
+      * left; right; assumption.
+      * right; constructor; [ constructor; auto | auto ].
+Qed.
+
+Theorem de_match_con {A} (tyname : string)
+    (c0 : list (string * A)) (c1 : list (string * FromSexpList A))
+    l (e : sexp) (a : A)
+  : Deser.match_con tyname c0 c1 l e = inr a ->
+    List.Exists (fun p => e = Atom (Raw (fst p)) /\ a = snd p) c0
+      \/ List.Exists (fun p => exists es,
+           List (Atom (Raw (fst p)) :: es) = e /\
+           inr a = snd p l (type_error tyname) es) c1.
+Proof.
+  unfold Deser.match_con.
+  intros DESER. apply de__con in DESER. destruct DESER as [ (c & Ee & Ea ) | (c & es & Ee & Ea) ].
+  - apply _find_or_spec in Ea. destruct Ea as [ Ea | [] ]; [ | discriminate ].
+    left. revert Ea; apply List.Exists_impl.
+    intros [] [Es Ea]; cbn in *.
+    apply CeresString.eqb_eq_string in Es.
+    injection Ea; intros.
+    subst. auto.
+  - apply _find_or_spec in Ea. destruct Ea as [ Ea | [] ]; [ | discriminate ].
+    right. revert Ea; apply List.Exists_impl.
+    intros [] [Es Ea]; cbn in *.
+    apply CeresString.eqb_eq_string in Es.
+    exists es.
+    subst; auto.
+Qed.
+
+Ltac elim_Exists H :=
+  match type of H with
+  | (List.Exists _ nil) => apply List.Exists_nil in H; destruct H
+  | (List.Exists _ (cons _ _)) => apply List.Exists_cons in H;
+    destruct H as [ H | H ]; [ | elim_Exists H ]
+  end.
+
+Instance SerDeClass_bool : SerDeClass bool.
+Proof.
+  unfold SerDeClass, SerDe.
+  intros l []; reflexivity.
+Qed.
+
+Instance DeSerClass_bool : DeSerClass bool.
+Proof.
+  intros l e a Ee; apply de_match_con in Ee.
+  destruct Ee as [ Ee | Ee ]; elim_Exists Ee;
+    destruct Ee as [Eatom Ea]; subst; try reflexivity.
+Qed.
+
+Instance SerDeClass_option {A} `{SerDeClass A} : SerDeClass (option A).
+Proof.
+  unfold SerDeClass, SerDe.
+  intros l []; cbn; [ rewrite H1 | ]; reflexivity.
+Qed.
+
+Section DeRetField.
+
+Context {R} (r : R) {n : nat}.
+
+Inductive UnnilFields : R -> list sexp -> Prop :=
+| MkUnnilFields : UnnilFields r nil
+.
+
+Lemma de_ret_field {a} l err es
+  : inr a = _fields (@Deser.ret R r n) l err es ->
+    UnnilFields a es.
+Proof.
+  destruct es; cbn.
+  - intros H; injection H; intros J; rewrite J; constructor.
+  - discriminate.
+Qed.
+
+End DeRetField.
+
+Section DeBindField.
+
+Context {A B} (pa : FromSexp A)
+    {n m : nat} (f : A -> FromSexpListN (S n) m B).
+
+Context (a : B) (es : list sexp) {l : loc} {err : message -> message}.
+
+Inductive UnconsFields : list sexp -> Prop :=
+| MkUnconsFields a' e' es'
+  : pa (n :: l) e' = inr a' ->
+    inr a = _fields (f a') l err es' ->
+    UnconsFields (e' :: es')
+.
+
+Lemma de_bind_field
+  : inr a = _fields (Deser.bind_field pa f) l err es ->
+    UnconsFields es.
+Proof.
+  destruct es; cbn; try discriminate.
+  destruct pa eqn:E1; cbn; try discriminate.
+  apply MkUnconsFields. assumption.
+Qed.
+
+End DeBindField.
+
+Ltac de_field Ea :=
+  (apply de_ret_field in Ea; destruct Ea) +
+  (let a1 := fresh "a" in
+   let e1 := fresh "e" in
+   let es := fresh "es" in
+   let Ea1 := fresh "Ea1" in
+   apply de_bind_field in Ea;
+   destruct Ea as [a1 e1 es Ea1 Ea];
+   de_field Ea).
+
+Instance DeSerClass_option {A} `{DeSerClass A} : DeSerClass (option A).
+Proof.
+  intros l e a Ee; apply de_match_con in Ee.
+  destruct Ee as [ Ee | Ee ]; elim_Exists Ee; cbn [fst snd] in *.
+  - destruct Ee as [E1 E2]; subst; reflexivity.
+  - destruct Ee as [es [Ee Ea]].
+    de_field Ea. cbn.
+    apply H1 in Ea1.
+    rewrite Ea1; assumption.
+Qed.


### PR DESCRIPTION
And other quality-of-life improvements (recursive deserialization!) Disabling tests for Coq <= 8.9 because a new test using `fix` does not work there.