### PR TITLE
CI: Add Coq 8.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,5 +51,11 @@ workflows:
           coq: '8.13'
           name: 'Coq 8.13'
       - test:
+          coq: '8.14'
+          name: 'Coq 8.14'
+      - test:
+          coq: '8.15'
+          name: 'Coq 8.15'
+      - test:
           coq: 'dev'
           name: 'Coq dev'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ jobs:
       OPAMWITHTEST: << parameters.runtest >>
       OPAMYES: true
       TERM: xterm
+      PACKAGES: >
+          coq-parsec
     steps:
       - checkout
       - run:
@@ -28,11 +30,14 @@ jobs:
       - run:
           name: Test dependants
           command: |
-            PINS=$(opam list -s --pinned --columns=package | xargs | tr ' ' ,)
-            PACKAGES=`opam list -s --depends-on coq-ceres --coinstallable-with $PINS`
-            if [ -n "$PACKAGES" ]
-            then opam install -t $PACKAGES
-            fi
+              for PACKAGE in $PACKAGES
+              do
+                DEPS_FAILED=false
+                (opam depext $PACKAGE &&
+                 opam install --deps-only -t $PACKAGE) || DEPS_FAILED=true
+                ([ $DEPS_FAILED == false ] && opam install $PACKAGE) ||
+                 echo Dependencies broken: $PACKAGE
+              done
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,14 @@ jobs:
       - run:
           name: Compile Cérès
           command: opam install ./coq-ceres.opam
+      - run:
+          name: Test dependants
+          command: |
+            PINS=$(opam list -s --pinned --columns=package | xargs | tr ' ' ,)
+            PACKAGES=`opam list -s --depends-on coq-ceres --coinstallable-with $PINS`
+            if [ -n "$PACKAGES" ]
+            then opam install -t $PACKAGES
+            fi
 
 workflows:
   version: 2


### PR DESCRIPTION
and test dependants.
Stable release lacking for Coq >= 8.14.